### PR TITLE
Remove useless access modifiers

### DIFF
--- a/lib/generic/net/proto.rb
+++ b/lib/generic/net/proto.rb
@@ -13,8 +13,6 @@ module Net
       ffi_convention :stdcall
     end
 
-    private
-
     # These should exist on every platform.
     attach_function :getprotobyname_c, :getprotobyname, [:string], :pointer
     attach_function :getprotobynumber_c, :getprotobynumber, [:int], :pointer
@@ -34,8 +32,6 @@ module Net
 
     private_class_method :getprotobyname_c
     private_class_method :getprotobynumber_c
-
-    public
 
     # If given a protocol string, returns the corresponding number. If
     # given a protocol number, returns the corresponding string.

--- a/lib/linux/net/proto.rb
+++ b/lib/linux/net/proto.rb
@@ -7,8 +7,6 @@ module Net
   class Proto
     ffi_lib FFI::Library::LIBC
 
-    private
-
     attach_function :setprotoent, [:int], :void
     attach_function :endprotoent, [], :void
     attach_function :getprotobyname_r, [:string, :pointer, :pointer, :long, :pointer], :int
@@ -17,8 +15,6 @@ module Net
 
     private_class_method :setprotoent, :endprotoent, :getprotobyname_r
     private_class_method :getprotobynumber_r, :getprotoent_r
-
-    public
 
     # If given a protocol string, returns the corresponding number. If
     # given a protocol number, returns the corresponding string.

--- a/lib/sunos/net/proto.rb
+++ b/lib/sunos/net/proto.rb
@@ -16,8 +16,6 @@ module Net
     private_class_method :setprotoent, :endprotoent, :getprotobyname_r
     private_class_method :getprotobynumber_r, :getprotoent_r
 
-    public
-
     # If given a protocol string, returns the corresponding number. If
     # given a protocol number, returns the corresponding string.
     #

--- a/lib/windows/net/proto.rb
+++ b/lib/windows/net/proto.rb
@@ -10,8 +10,6 @@ module Net
     ffi_lib 'ws2_32'
     ffi_convention :stdcall
 
-    private
-
     # These should exist on every platform.
     attach_function :getprotobyname_c, :getprotobyname, [:string], :pointer
     attach_function :getprotobynumber_c, :getprotobynumber, [:int], :pointer
@@ -24,8 +22,6 @@ module Net
     private_class_method :WSAAsyncGetProtoByName
     private_class_method :WSAAsyncGetProtoByNumber
     private_class_method :WSAGetLastError
-
-    public
 
     # If given a protocol string, returns the corresponding number. If
     # given a protocol number, returns the corresponding string.


### PR DESCRIPTION
These do nothing, and the singleton methods were already marked privately the right way.