### PR TITLE
Change p_proto struct member to short on Windows

### DIFF
--- a/lib/net/proto/common.rb
+++ b/lib/net/proto/common.rb
@@ -10,11 +10,19 @@ module Net
     private_class_method :new
 
     class ProtocolStruct < FFI::Struct
-      layout(
-        :p_name,    :string,
-        :p_aliases, :pointer,
-        :p_proto,   :int
-      )
+      if File::ALT_SEPARATOR
+        layout(
+          :p_name,    :string,
+          :p_aliases, :pointer,
+          :p_proto,   :short
+        )
+      else
+        layout(
+          :p_name,    :string,
+          :p_aliases, :pointer,
+          :p_proto,   :int
+        )
+      end
     end
 
     class FFI::Pointer


### PR DESCRIPTION
Technically the `p_proto` struct member is a short on Windows instead of an int.

Mainly I'm doing this to see if it's the source of a github action failure.